### PR TITLE
Make card payloads compatible with ember-mobiledoc-editor

### DIFF
--- a/addon/templates/components/render-mobiledoc.hbs
+++ b/addon/templates/components/render-mobiledoc.hbs
@@ -1,6 +1,6 @@
 <div class='__rendered-mobiledoc'></div>
 {{#each _componentCards as |card|}}
   {{#ember-wormhole to=card.destinationElementId}}
-    {{component card.componentName payload=card.payload}}
+    {{component card.componentName data=card.payload}}
   {{/ember-wormhole}}
 {{/each}}

--- a/tests/dummy/app/templates/components/sample-card.hbs
+++ b/tests/dummy/app/templates/components/sample-card.hbs
@@ -1,1 +1,1 @@
-<h3>sample!!!!!!! foo: {{payload.foo}}</h3>
+<h3>sample!!!!!!! foo: {{data.foo}}</h3>

--- a/tests/dummy/app/templates/components/sample-changed-name-test-card.hbs
+++ b/tests/dummy/app/templates/components/sample-changed-name-test-card.hbs
@@ -1,3 +1,3 @@
 <div id='sample-changed-name-test-card'>
-  foo: {{payload.foo}}
+  foo: {{data.foo}}
 </div>

--- a/tests/dummy/app/templates/components/sample-test-card.hbs
+++ b/tests/dummy/app/templates/components/sample-test-card.hbs
@@ -1,3 +1,3 @@
 <div id='sample-test-card'>
-  foo: {{payload.foo}}
+  foo: {{data.foo}}
 </div>


### PR DESCRIPTION
ember-mobiledoc-editor passes the payload to card components as `data`, but ember-mobiledoc-dom-renderer passes the payload as `payload`. This makes it awkward to use the same set of display card components in both environments.

This change standardizes on `data`, mostly because it meant changing the simpler side. But I think `payload` is a better name, and we could also change the editor to that instead.