### PR TITLE
Use `willRender` instead of `didInsertElement`, make fastboot-compatible

### DIFF
--- a/addon/components/render-mobiledoc.js
+++ b/addon/components/render-mobiledoc.js
@@ -3,34 +3,59 @@ import Renderer from 'ember-mobiledoc-dom-renderer';
 import { RENDER_TYPE } from 'ember-mobiledoc-dom-renderer';
 import layout from '../templates/components/render-mobiledoc';
 
-let { $, computed, assert } = Ember;
-let { run: { schedule, join } } = Ember;
+const {
+  assert,
+  computed,
+  run: { join },
+  uuid,
+  $
+} = Ember;
 
 const ADD_CARD_HOOK      = 'addComponentCard';
 const REMOVE_CARD_HOOK   = 'removeComponentCard';
 const ADD_ATOM_HOOK      = 'addComponentAtom';
 const REMOVE_ATOM_HOOK   = 'removeComponentAtom';
 
-const COMPONENT_NAME          = 'render-mobiledoc';
-const ELEMENT_CLASS = '__rendered-mobiledoc';
-const UUID_PREFIX   = '__rendered-mobiledoc-card-';
+const UUID_PREFIX               = '__rendered-mobiledoc-entity-';
 export const CARD_ELEMENT_CLASS = '__rendered-mobiledoc-card';
 export const ATOM_ELEMENT_CLASS = '__rendered-mobiledoc-atom';
+
+const CARD_HOOKS = {
+  ADD:    ADD_CARD_HOOK,
+  REMOVE: REMOVE_CARD_HOOK
+};
+
+const ATOM_HOOKS = {
+  ADD:    ADD_ATOM_HOOK,
+  REMOVE: REMOVE_ATOM_HOOK
+};
+
+function rendererFor(type) {
+  let hookNames;
+
+  if (type === 'card') {
+    hookNames = CARD_HOOKS;
+  } else if (type === 'atom') {
+    hookNames = ATOM_HOOKS;
+  }
+
+  return function({env, options}) {
+    let { onTeardown } = env;
+    let addHook    = options[hookNames.ADD];
+    let removeHook = options[hookNames.REMOVE];
+
+    let { entity, element } = addHook(...arguments);
+    onTeardown(() => removeHook(entity));
+
+    return element;
+  };
+}
 
 function createComponentCard(name) {
   return {
     name,
     type: RENDER_TYPE,
-    render({env, options}) {
-      let addHook = options[ADD_CARD_HOOK];
-      let removeHook = options[REMOVE_CARD_HOOK];
-      let { onTeardown } = env;
-
-      let { card, element } = addHook(...arguments);
-      onTeardown(() => removeHook(card));
-
-      return element;
-    }
+    render: rendererFor('card')
   };
 }
 
@@ -38,21 +63,17 @@ function createComponentAtom(name) {
   return {
     name,
     type: RENDER_TYPE,
-    render({env, options}) {
-      let addHook = options[ADD_ATOM_HOOK];
-      let removeHook = options[REMOVE_ATOM_HOOK];
-      let { onTeardown } = env;
-
-      let { atom, element } = addHook(...arguments);
-      onTeardown(() => removeHook(atom));
-
-      return element;
-    }
+    render: rendererFor('atom')
   };
 }
 
 export default Ember.Component.extend({
   layout: layout,
+
+  didReceiveAttrs() {
+    let mobiledoc = this.get('mobiledoc');
+    assert(`Must pass mobiledoc to render-mobiledoc component`, !!mobiledoc);
+  },
 
   // pass in an array of card names that the mobiledoc may have. These
   // map to component names using `cardNameToComponentName`
@@ -70,13 +91,27 @@ export default Ember.Component.extend({
     return this.get('atomNames').map(name => createComponentAtom(name));
   }),
 
-  _renderMobiledoc: Ember.observer('mobiledoc', '_mdcCards', Ember.on('didInsertElement', function() {
-    if (this._teardownRender) {
-      this._teardownRender();
-      this._teardownRender = null;
-    }
+  willRender() {
+    let emberRenderer = this.get('renderer');
+    let dom = emberRenderer && emberRenderer._dom;
+    assert('Unable to get renderer dom helper', !!dom);
 
-    let cardOptions = {
+    let cards = this.get('_mdcCards');
+    let atoms = this.get('_mdcAtoms');
+    let mobiledoc = this.get('mobiledoc');
+    let cardOptions = this.get('_cardOptions');
+
+    let renderer = new Renderer({atoms, cards, cardOptions, dom});
+    let { result, teardown } = renderer.render(mobiledoc);
+
+    this.set('renderedMobiledoc', result);
+    this._teardownRender = teardown;
+
+    this._super(...arguments);
+  },
+
+  _cardOptions: computed(function() {
+    return {
       [ADD_CARD_HOOK]: ({env, options, payload}) => {
         let { name: cardName } = env;
         let uuid = this.generateUuid();
@@ -117,18 +152,7 @@ export default Ember.Component.extend({
       [REMOVE_CARD_HOOK]: (card) => this.removeCard(card),
       [REMOVE_ATOM_HOOK]: (atom) => this.removeAtom(atom)
     };
-
-    let cards = this.get('_mdcCards');
-    let atoms = this.get('_mdcAtoms');
-    let mobiledoc = this.get('mobiledoc');
-    assert(`Must pass mobiledoc to "${COMPONENT_NAME}" component`, !!mobiledoc);
-
-    let renderer = new Renderer({cards, atoms, cardOptions});
-    let { result, teardown } = renderer.render(mobiledoc);
-    this.getRenderElement().appendChild(result);
-
-    this._teardownRender = teardown;
-  })),
+  }),
 
   willDestroyElement() {
     if (this._teardownRender) {
@@ -158,9 +182,7 @@ export default Ember.Component.extend({
   }),
 
   addCard(card) {
-    schedule('afterRender', () => {
-      this.get('_componentCards').pushObject(card);
-    });
+    this.get('_componentCards').pushObject(card);
   },
 
   removeCard(card) {
@@ -170,9 +192,7 @@ export default Ember.Component.extend({
   },
 
   addAtom(atom) {
-    schedule('afterRender', () => {
-      this.get('_componentAtoms').pushObject(atom);
-    });
+    this.get('_componentAtoms').pushObject(atom);
   },
 
   removeAtom(atom) {
@@ -181,11 +201,7 @@ export default Ember.Component.extend({
     });
   },
 
-  getRenderElement() {
-    return this.$('.' + ELEMENT_CLASS)[0];
-  },
-
   generateUuid() {
-    return `${UUID_PREFIX}${Ember.uuid()}`;
+    return `${UUID_PREFIX}${uuid()}`;
   }
 });

--- a/addon/templates/components/render-mobiledoc.hbs
+++ b/addon/templates/components/render-mobiledoc.hbs
@@ -1,4 +1,5 @@
-<div class='__rendered-mobiledoc'></div>
+{{renderedMobiledoc}}
+
 {{#each _componentCards as |card|}}
   {{#ember-wormhole to=card.destinationElementId}}
     {{component card.componentName payload=card.payload}}

--- a/tests/dummy/app/components/sample-test-atom.js
+++ b/tests/dummy/app/components/sample-test-atom.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: ''
+});

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,24 +1,54 @@
 import Ember from 'ember';
 
-let { computed } = Ember;
+let mobiledocs = {
+  simple: {
+    version: '0.3.0',
+    markups: [],
+    cards: [],
+    atoms: [],
+    sections: [
+      [1, 'P', [
+        [0, [], 0, 'Hello world!']
+      ]]
+    ]
+  },
+  card: {
+    version: '0.3.0',
+    markups: [],
+    cards: [['sample-card', {}]],
+    atoms: [],
+    sections: [
+      [10, 0]
+    ]
+  },
+  atom: {
+    version: '0.3.0',
+    markups: [],
+    cards: [],
+    atoms: [['sample-test-atom', 'bob', {foo: 'bar'}]],
+    sections: [
+      [1, 'P', [
+        [0, [], 0, 'Hello card'],
+        [1, 0, [], 0],
+        [0, [], 0, '!']
+      ]]
+    ]
+  }
+};
 
 export default Ember.Controller.extend({
+  init() {
+    this._super(...arguments);
+    this.set('mobiledoc', mobiledocs['simple']);
+    this.set('mobiledocNames', Object.keys(mobiledocs));
+  },
+
   cardNames: ['sample-card'],
-  mobiledoc: computed(function() {
-    return {
-      version: '0.2.0',
-      sections: [
-        [],
-        [
-          [1, 'P', [
-            [[], 0, 'Hello world!']
-          ]],
-          [10, 'sample-card', {foo: 'bar'}],
-          [1, 'P', [
-            [[], 0, 'Hello world!']
-          ]],
-        ]
-      ]
-    };
-  })
+  atomNames: ['sample-test-atom'],
+
+  actions: {
+    selectMobiledoc({target: {value}}) {
+      this.set('mobiledoc', mobiledocs[value]);
+    }
+  }
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,2 +1,8 @@
-<h2>rendererd:</h2>
-{{render-mobiledoc mobiledoc=mobiledoc cardNames=cardNames}}
+<select onchange={{action 'selectMobiledoc'}}>
+  {{#each mobiledocNames as |name|}}
+    <option value={{name}}>{{name}}</option>
+  {{/each}}
+</select>
+
+<h2>rendered:</h2>
+{{render-mobiledoc mobiledoc=mobiledoc cardNames=cardNames atomNames=atomNames}}


### PR DESCRIPTION
Also update the dummy app and add other refactorings to simplify
the renderer component.
Passes ember's renderer's dom helper to the mobiledoc-dom-renderer to allow it
to work properly in fastboot.