### PR TITLE
[WIP] Remove cards and atoms before teardown or re-rendering.

### DIFF
--- a/addon/components/render-mobiledoc.js
+++ b/addon/components/render-mobiledoc.js
@@ -92,6 +92,20 @@ export default Ember.Component.extend({
   }),
 
   willRender() {
+    /*
+     We need to figure why this this is getting called after rendering
+     the same payload somewhere else. Since the editor is destroyed
+     and rendered again, wormhole goes into a weird state because it
+     doesn't find the destination elements. Related with
+     https://github.com/bustlelabs/ember-mobiledoc-dom-renderer/issues/19
+
+     Also there is a a double render.
+     */
+    this.beginPropertyChanges();
+    this.get('_componentCards').clear();
+    this.get('_componentAtoms').clear();
+    this.endPropertyChanges();
+
     let emberRenderer = this.get('renderer');
     let dom = emberRenderer && emberRenderer._dom;
     assert('Unable to get renderer dom helper', !!dom);
@@ -147,6 +161,12 @@ export default Ember.Component.extend({
   }),
 
   willDestroyElement() {
+    // clean up cards and atoms so wormhole doesn't try to render
+    // them after mobiledoc has been destroy
+    this.beginPropertyChanges();
+    this.get('_componentCards').clear();
+    this.get('_componentAtoms').clear();
+    this.endPropertyChanges();
     if (this._teardownRender) {
       this._teardownRender();
     }


### PR DESCRIPTION
I was getting trolled with the following error:

```
Assertion failed: Error: ember-wormhole failed to render into '#__rendered-mobiledoc-entity-1332' because the element is not in the DOM(…)
```

After chasing it down, the problem was that the editor was being teardown while cards and atoms were still in the list, so wormhole was trying to render but failing. 

@bantic I think this is also related with https://github.com/bustlelabs/ember-mobiledoc-dom-renderer/issues/19 

It would be nice to add some tests, but I haven't had the time to do that yet.