### PR TITLE
Ensure changing card or atom payload or value doesn't cause rerender loop

### DIFF
--- a/addon/templates/components/render-mobiledoc.hbs
+++ b/addon/templates/components/render-mobiledoc.hbs
@@ -2,11 +2,11 @@
 
 {{#each _componentCards as |card|}}
   {{#ember-wormhole to=card.destinationElementId}}
-    {{component card.componentName payload=card.payload}}
+    {{component card.componentName payload=(readonly card.payload)}}
   {{/ember-wormhole}}
 {{/each}}
 {{#each _componentAtoms as |atom|}}
   {{#ember-wormhole to=atom.destinationElementId}}
-    {{component atom.componentName payload=atom.payload value=atom.value}}
+    {{component atom.componentName payload=(readonly atom.payload) value=(readonly atom.value)}}
   {{/ember-wormhole}}
 {{/each}}


### PR DESCRIPTION
Adds a failing test for #19 
Also: refactor tests to use functions that generate mobiledocs