### PR TITLE
Run tests on ember beta, release, canary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "6.2.0"
 
-sudo: false
+sudo: required
+dist: trusty
 
 cache:
   directories:
@@ -12,18 +13,20 @@ cache:
 env:
   - EMBER_TRY_SCENARIO=1.13
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=2.3
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm install -g npm@^3
+  - npm config set progress false
+  - npm install -g phantomjs-prebuilt
 
 install:
   - npm install -g bower

--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -1,0 +1,10 @@
+export function getDOM(context) {
+  let { renderer } = context;
+  if (renderer._dom) { // pre glimmer2
+    return renderer._dom;
+  } else if (renderer._env && renderer._env.getDOM) { // glimmer 2
+    return renderer._env.getDOM();
+  } else {
+    throw new Error('Unable to get DOM helper');
+  }
+}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       name: '1.13',
       dependencies: {
-        "ember": "~1.13.7"
+        "ember": "^1.13"
       }
     },
     {
@@ -11,9 +11,21 @@ module.exports = {
       dependencies: { }
     },
     {
-      name: '2.3',
+      name: 'ember-release',
       dependencies: {
-        'ember': '2.3.0-beta.1'
+        'ember': 'components/ember#release'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: {
+        'ember': 'beta'
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-mobiledoc-dom-renderer",
   "version": "0.5.2",
-  "description": "provides mobiledoc-dom-renderer to ember apps",
+  "description": "provides a runtime mobiledoc dom-renderer to ember apps",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -38,7 +38,9 @@
     "ember-try": "0.0.6"
   },
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "mobiledoc",
+    "mobiledoc-kit"
   ],
   "dependencies": {
     "broccoli-funnel": "^1.0.0",


### PR DESCRIPTION
 * Fix failing tests when using ember with glimmer2.
 * Access DOM helper using a method that is safe for both pre-glimmer2 and
glimmer2.
 * Wrap the renderedMobiledoc documentFragment in a wrapper div
   (necessary for glimmer2 teardown, see
   https://github.com/tildeio/glimmer/pull/331 and
   https://github.com/yapplabs/ember-wormhole/issues/66#issuecomment-246207622)
 * Fixes #18.
 * Update travis node version.
 * Update package keywords and description.