### PR TITLE
Pass cardOptions to cards and atoms

### DIFF
--- a/addon/components/render-mobiledoc.js
+++ b/addon/components/render-mobiledoc.js
@@ -3,6 +3,7 @@ import Renderer from 'ember-mobiledoc-dom-renderer';
 import { RENDER_TYPE } from 'ember-mobiledoc-dom-renderer';
 import layout from '../templates/components/render-mobiledoc';
 import { getDocument } from '../utils/document';
+import assign from '../utils/polyfilled-assign';
 
 const {
   assert,
@@ -106,8 +107,7 @@ export default Ember.Component.extend({
     let options = {
       dom,
       cards: this.get('_mdcCards'),
-      atoms: this.get('_mdcAtoms'),
-      cardOptions: this.get('_cardOptions')
+      atoms: this.get('_mdcAtoms')
     };
     [
       'mobiledoc', 'sectionElementRenderer', 'markupElementRenderer',
@@ -118,6 +118,10 @@ export default Ember.Component.extend({
         options[option] = value;
       }
     });
+
+    let passedOptions = this.get('cardOptions');
+    let cardOptions = this.get('_cardOptions');
+    options.cardOptions = passedOptions ? assign(passedOptions, cardOptions) : cardOptions;
 
     let renderer = new Renderer(options);
     let { result, teardown } = renderer.render(mobiledoc);
@@ -144,7 +148,8 @@ export default Ember.Component.extend({
         let card = {
           componentName,
           destinationElementId: element.getAttribute('id'),
-          payload
+          payload,
+          options
         };
         this.addCard(card);
         return { entity: card, element };
@@ -159,7 +164,8 @@ export default Ember.Component.extend({
           componentName,
           destinationElementId: element.getAttribute('id'),
           payload,
-          value
+          value,
+          options
         };
         this.addAtom(atom);
         return { entity: atom, element };

--- a/addon/templates/components/render-mobiledoc.hbs
+++ b/addon/templates/components/render-mobiledoc.hbs
@@ -2,11 +2,11 @@
 
 {{#each _componentCards as |card|}}
   {{#ember-wormhole to=card.destinationElementId}}
-    {{component card.componentName payload=(readonly card.payload)}}
+    {{component card.componentName options=(readonly card.options) payload=(readonly card.payload)}}
   {{/ember-wormhole}}
 {{/each}}
 {{#each _componentAtoms as |atom|}}
   {{#ember-wormhole to=atom.destinationElementId}}
-    {{component atom.componentName payload=(readonly atom.payload) value=(readonly atom.value)}}
+    {{component atom.componentName options=(readonly atom.options) payload=(readonly atom.payload) value=(readonly atom.value)}}
   {{/ember-wormhole}}
 {{/each}}

--- a/addon/utils/polyfilled-assign.js
+++ b/addon/utils/polyfilled-assign.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+const { merge, assign } = Ember;
+
+let polyfilledAssign = assign || merge;
+
+export default polyfilledAssign;
+

--- a/tests/integration/components/render-mobiledoc-test.js
+++ b/tests/integration/components/render-mobiledoc-test.js
@@ -174,13 +174,7 @@ test('changing mobiledoc calls teardown and destroys atom component', function(a
   this.set('mobiledoc', createMobiledocWithAtom('test-atom'));
   this.set('atomNames', ['test-atom', 'other-atom']);
 
-  let MyRenderComponent = this.container.lookupFactory('component:render-mobiledoc');
   let didDestroy = [], didInsert = [];
-  this.registry.register('component:my-render-mobiledoc', MyRenderComponent.extend({
-    willDestroy() {
-      didDestroy.push('my-render-mobiledoc');
-    }
-  }));
 
   this.registry.register('component:test-atom', Ember.Component.extend({
     didInsertElement() { didInsert.push('test-atom'); },
@@ -191,7 +185,7 @@ test('changing mobiledoc calls teardown and destroys atom component', function(a
     willDestroy() { didDestroy.push('other-atom'); }
   }));
 
-  this.render(hbs`{{my-render-mobiledoc mobiledoc=mobiledoc atomNames=atomNames}}`);
+  this.render(hbs`{{render-mobiledoc mobiledoc=mobiledoc atomNames=atomNames}}`);
 
   assert.deepEqual(didDestroy, [], 'nothing destroyed');
   assert.deepEqual(didInsert, ['test-atom'], 'test-atom inserted');
@@ -352,4 +346,40 @@ test('Can pass markupElementRenderer', function(assert) {
   this.render(hbs`{{render-mobiledoc mobiledoc=mobiledoc markupElementRenderer=markupElementRenderer}}`);
 
   assert.ok(this.$('span:contains(Hi)').length, 'renders mobiledoc');
+});
+
+test('Can pass cardOptions and they appear for cards', function(assert) {
+  assert.expect(1);
+  let passedOption = {};
+  let cardName = 'my-card';
+  this.set('mobiledoc', createMobiledocWithCard(cardName));
+  this.set('cardNames', [cardName]);
+  this.set('cardOptions', {passedOption});
+  let CardComponent = Ember.Component.extend({
+    init() {
+      this._super(...arguments);
+      assert.equal(this.options.passedOption, passedOption);
+    }
+  });
+  this.registry.register('component:my-card', CardComponent);
+
+  this.render(hbs`{{render-mobiledoc mobiledoc=mobiledoc cardNames=cardNames cardOptions=cardOptions}}`);
+});
+
+test('Can pass cardOptions and they appear for atoms', function(assert) {
+  assert.expect(1);
+  let passedOption = {};
+  let atomName = 'my-atom';
+  this.set('mobiledoc', createMobiledocWithAtom(atomName));
+  this.set('atomNames', [atomName]);
+  this.set('cardOptions', {passedOption});
+  let AtomComponent = Ember.Component.extend({
+    init() {
+      this._super(...arguments);
+      assert.equal(this.options.passedOption, passedOption);
+    }
+  });
+  this.registry.register('component:my-atom', AtomComponent);
+
+  this.render(hbs`{{render-mobiledoc mobiledoc=mobiledoc atomNames=atomNames cardOptions=cardOptions}}`);
 });


### PR DESCRIPTION
Akin to https://github.com/bustlelabs/ember-mobiledoc-editor/pull/125, this allows the user to pass cardOptions through to cards an atoms.