### PR TITLE
WIP Change lookup path for mobiledoc-dom-renderer modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
   name: 'ember-mobiledoc-dom-renderer',
 
   treeForAddon: function(tree) {
-    var libRoot = require.resolve('mobiledoc-dom-renderer/lib');
+    var libRoot = require.resolve('mobiledoc-dom-renderer/dist/modules/es2017');
     var libPath = path.dirname(libRoot);
 
     var rendererTree = new Funnel(libPath, {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-getowner-polyfill": "^1.2.2",
     "ember-wormhole": "^0.5.1",
-    "mobiledoc-dom-renderer": "^0.5.1"
+    "mobiledoc-dom-renderer": "^0.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
**do not merge**

This WIP PR is meant to be used/tested with the changes in https://github.com/bustlelabs/mobiledoc-dom-renderer/pull/40.

Summary:
 * index.js now expects the path to match the one that @glimmer/build
outputs.

Uses the mobiledoc-dom-renderer from https://github.com/bustlelabs/mobiledoc-dom-renderer/pull/40.
