### PR TITLE
Use latest mobiledoc-dom-renderer (^0.6.3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
   name: 'ember-mobiledoc-dom-renderer',
 
   treeForAddon: function(tree) {
-    var libRoot = require.resolve('mobiledoc-dom-renderer/dist/modules/es2017');
+    var libRoot = require.resolve('mobiledoc-dom-renderer/lib');
     var libPath = path.dirname(libRoot);
 
     var rendererTree = new Funnel(libPath, {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-getowner-polyfill": "^1.2.2",
     "ember-wormhole": "^0.5.1",
-    "mobiledoc-dom-renderer": "^0.6.2"
+    "mobiledoc-dom-renderer": "^0.6.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
It reverted use of glimmer/build in favor of the previous build system,
so this commit changes the lookup path that the addon uses to find the
es modules for mobiledoc-dom-renderer.