### PR TITLE
Add env to atom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To pass atom names to the renderer, use the `atomNames` property, e.g.:
 {{render-mobiledoc mobiledoc=myMobileDoc atomNames=myAtomNames}}
 ```
 
-The component will be passed a `payload` and `value` property.
+The component will be passed a `payload`, `value`, `options`, and `env` properties.
 
 To customize atom lookup, extend the `render-mobiledoc` component and override
 its `atomNameToComponentName` method.

--- a/addon/components/render-mobiledoc.js
+++ b/addon/components/render-mobiledoc.js
@@ -165,7 +165,8 @@ export default Ember.Component.extend({
           destinationElementId: element.getAttribute('id'),
           payload,
           value,
-          options
+          options,
+          env
         };
         this.addAtom(atom);
         return { entity: atom, element };

--- a/addon/templates/components/render-mobiledoc.hbs
+++ b/addon/templates/components/render-mobiledoc.hbs
@@ -7,6 +7,6 @@
 {{/each}}
 {{#each _componentAtoms as |atom|}}
   {{#ember-wormhole to=atom.destinationElementId}}
-    {{component atom.componentName options=(readonly atom.options) payload=(readonly atom.payload) value=(readonly atom.value)}}
+    {{component atom.componentName env=atom.env options=(readonly atom.options) payload=(readonly atom.payload) value=(readonly atom.value)}}
   {{/ember-wormhole}}
 {{/each}}


### PR DESCRIPTION
This allows the component to control things like `env.save(value, payload)` to trigger a rerender of the atom.